### PR TITLE
Fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ add(2)(5); // 7
 ```javascript
 ( window.foo || ( window.foo = "bar" ) );
 ```
-**Answer: "bar"** *(only if `window.foo` was falsey otherwise it will retain its value)*
+**Answer: "bar"** **(only if `window.foo` is truthy, does it retain its value)**
 
 
 *Question: What is the outcome of the two alerts below?*


### PR DESCRIPTION
_Question: What is the value of window.foo?_

``` javascript
( window.foo || ( window.foo = "bar" ) );
```

**Answer: "bar"** _(only if window.foo was falsey otherwise it will retain its value)_
is better as
**Answer: "bar"** _(only if `window.foo` is truthy, does it retain its value)_

The new explanation is both less wordy and less confusing.
