### PR TITLE
Fixes a grammar error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This file contains a number of front-end interview questions that can be used wh
 
 #### HTML Questions:
 
-* What's a `doctype` do?
+* What does a `doctype` do?
 * What's the difference between standards mode and quirks mode?
 * What are the limitations when serving XHTML pages?
 * Are there any problems with serving pages as `application/xhtml+xml`?


### PR DESCRIPTION
"What's a doctype do?" sounds wrong to me, as least formally. See: [Is “what’s” a correct short form of “what does”?](Is “what’s” a correct short form of “what does”?). When not one myself, I've double-checked with several native speakers on this.
And sorry for being nitpicking.