### PR TITLE
Changed the XHTML question

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This file contains a number of front-end interview questions that can be used wh
 
 * What does a `doctype` do?
 * What's the difference between standards mode and quirks mode?
-* What are the limitations when serving XHTML pages?
+* What's the difference between HTML and XHTML?
 * Are there any problems with serving pages as `application/xhtml+xml`?
 * How do you serve a page with content in multiple languages?
 * What kind of things must you be wary of when design or developing for multilingual sites?


### PR DESCRIPTION
The original question 

> What are the limitations when serving XHTML pages?

~~is believed to be taken from [here](http://www.skilledup.com/articles/html-html5-interview-questions-answers/) (along with several others)~~ (EDITED: I couldn't be more wrong, as corrected by @darcyclarke below). While there's nothing wrong with it, I believe it has the protential to extract more about a candidate skills and knowledge if he's asked to compare HTML and XHTML instead. 

Just my $0.02. Would be happy if you guys can correct me.