### PR TITLE
JS Questions: removed "Describe event bubbling"

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ This file contains a number of front-end interview questions that can be used wh
 * Have you ever used JavaScript templating?
   * If so, what libraries have you used?
 * Explain "hoisting".
-* Describe event bubbling.
 * What's the difference between an "attribute" and a "property"?
 * Why is extending built-in JavaScript objects not a good idea?
 * Difference between document load event and document DOMContentLoaded event?


### PR DESCRIPTION
The question is more or less a duplicate of the first JS Question "Explain event delegation".
Note that the jQuery documentation (https://learn.jquery.com/events/event-delegation/) says: "...This is called event bubbling or event propagation."
I would expect a candidate to mention event bubbling in scope of explaining event delegation.
