### PR TITLE
remove duplicate question and rephrase an old one

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This file contains a number of front-end interview questions that can be used wh
 
 #### CSS Questions:
 
-* What CSS selector specificity and how does it work?
+* What is CSS selector specificity and how does it work?
 * What's the difference between "resetting" and "normalizing" CSS? Which would you choose, and why?
 * Describe Floats and how they work.
 * Describe z-index and how stacking context is formed.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This file contains a number of front-end interview questions that can be used wh
 
 #### CSS Questions:
 
-* What is the difference between classes and IDs in CSS?
+* What CSS selector specificity and how does it work?
 * What's the difference between "resetting" and "normalizing" CSS? Which would you choose, and why?
 * Describe Floats and how they work.
 * Describe z-index and how stacking context is formed.
@@ -92,7 +92,6 @@ This file contains a number of front-end interview questions that can be used wh
 * List as many values for the display property that you can remember.
 * What's the difference between inline and inline-block?
 * What's the difference between a relative, fixed, absolute and statically positioned element?
-* The 'C' in CSS stands for Cascading.  How is priority determined in assigning styles (a few examples)?  How can you use this system to your advantage?
 * What existing CSS frameworks have you used locally, or in production? How would you change/improve them?
 * Have you played around with the new CSS Flexbox or Grid specs?
 * How is responsive design different from adaptive design?


### PR DESCRIPTION
The differences between an ID and class in CSS all comes down to specificity, so I am suggesting that this question be updated to ask exactly that. Any other question lends itself to open-ended conversation about IDs needing to be unique, but that is specification of the HTML attribute, not the ID as per the CSS specification. 

I would also argue then that the question "The 'C' in CSS stands for Cascading. How is priority determined in assigning styles (a few examples)? How can you use this system to your advantage?" should also be removed. 

This again is really a question about specificity and the order in which the CSS is written in the stylesheet.

The question, "How can you use this system to your advantage?" I am particularly uncomfortable with. The answer to this is to use specificity as a hammer to combat the natural flow of the cascade, and as discussed, this is a BAD thing in most cases. 