### PR TITLE
adds question about differences between option and datalist elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This file contains a number of front-end interview questions that can be used wh
 * What is progressive rendering?
 * Why you would use a `srcset` attribute in an image tag? Explain the process the browser uses when evaluating the content of this attribute.
 * Have you used different HTML templating languages before?
+* Can you explain the main difference between using a `<select>` versus a `<datalist>` element?
 
 #### CSS Questions:
 


### PR DESCRIPTION
# Pull Request

Recently asked this question by a peer intern developer, thought it would be a good question to consider. 

The anticipated response would be that the `option` element locks a user into a pre-defined series of answers that a user must choose from. Whereas the `datalist` element is used in conjunction with a `input` element and is a list of suggested inputs, but the user has the opportunity to free-text enter as well. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
