### PR TITLE
Fix broken links for Contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This file contains a number of front-end interview questions that can be used wh
 ## Getting Involved
 
   1. [Contributors](#contributors)
-  1. [How to Contribute](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/CONTRIBUTING.md)
+  1. [How to Contribute](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/.github/CONTRIBUTING.md)
   1. [License](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/LICENSE.md)
 
 ## Contributors:
@@ -34,4 +34,4 @@ This project is currently maintained by:
 
 It has since been active thanks to these [incredibly wonderful people](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/CONTRIBUTORS.md).
 
-Feeling inspired? Check our [Contributing guide](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/CONTRIBUTING.md) to get started!
+Feeling inspired? Check our [Contributing guide](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/.github/CONTRIBUTING.md) to get started!


### PR DESCRIPTION
I have fixed/updated the links to Contributing.md file which was moved to .github folder, which broke the links in the original Readme.md file. I stumbled upon this bug as I was getting 404 error page when I wanted to check how to contribute.

Fixes # (Two broken links for contributing guidelines in Readme.md file.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Simply click the updated link. It leads to the Contributing.md file again.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
