### PR TITLE
Should be window load instead of document load

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -27,7 +27,7 @@
 * Describe event bubbling.
 * What's the difference between an "attribute" and a "property"?
 * Why is extending built-in JavaScript objects not a good idea?
-* Difference between document load event and document DOMContentLoaded event?
+* Difference between window load event and document DOMContentLoaded event?
 * What is the difference between `==` and `===`?
 * Explain the same-origin policy with regards to JavaScript.
 * Make this work:


### PR DESCRIPTION
# Pull Request Template

Im pretty sure this is a mistake, as document.load and document DOMContentLoaded are the same thing. (actually, document.load doesn't exist)
I don't know who wrote the original question but my guess is they were asking to compare window.load and document.DOMContentLoaded

## Type of change

- [ ] Revision of an existing question


# Checklist:

- [ ] My prose follows the style guidelines of this project
- [ ] I have performed a self-review of my own prose

