### PR TITLE
remove document write question

### DIFF
--- a/questions/javascript-questions.md
+++ b/questions/javascript-questions.md
@@ -16,7 +16,6 @@
 * Difference between: `function Person(){}`, `var person = Person()`, and `var person = new Person()`?
 * What's the difference between `.call` and `.apply`?
 * Explain `Function.prototype.bind`.
-* When would you use `document.write()`?
 * What's the difference between feature detection, feature inference, and using the UA string?
 * Explain Ajax in as much detail as possible.
 * What are the advantages and disadvantages of using Ajax?


### PR DESCRIPTION
# Pull Request Template

I don't see any need to ask this question, there's no good reason to use document.write. 
As we're looking to cut down on JS questions, this feels like a good one to go.

Its not even recommended to be used anymore, and has performance issues.
Asking about it in an interview feels like a waste of time.
https://developers.google.com/web/updates/2016/08/removing-document-write

## Type of change

Please delete options that are not relevant.

- [ ] Revision of an existing question

# Checklist:

- [ ] My prose follows the style guidelines of this project
- [ ] I have performed a self-review of my own prose