### PR TITLE
 Add question about pseduo-elements

### DIFF
--- a/questions/css-questions.md
+++ b/questions/css-questions.md
@@ -13,6 +13,7 @@
 * Have you ever used a grid system, and if so, what do you prefer?
 * Have you used or implemented media queries or mobile specific layouts/CSS?
 * Are you familiar with styling SVG?
+* What is an example of an pseduo-element?
 * Can you give an example of an `@media` property other than `screen`?
 * What are some of the "gotchas" for writing efficient CSS?
 * What are the advantages/disadvantages of using CSS preprocessors?


### PR DESCRIPTION
# Add question about Pseduo-elements

Pseduo-elements are an efficient method to style elements without writing new syntax. Using this, we can insert additional content into a page without having to write interactive JS. 

I've asked this question during a number of interviews and have found that it allows for a much clearer understanding of a candidates CSS abilities. 

Please delete options that are not relevant.

- [X] New Question

# Checklist:

- [X] My prose follows the style guidelines of this project
- [X] I have performed a self-review of my own prose