### PR TITLE
Add comparison question about nth-of-type() and nth-child()

### DIFF
--- a/questions/css-questions.md
+++ b/questions/css-questions.md
@@ -24,6 +24,7 @@
 * What does ```* { box-sizing: border-box; }``` do? What are its advantages?
 * What is the CSS `display` property and can you give a few examples of its use?
 * What's the difference between inline and inline-block?
+* What's the difference between the "nth-of-type()" and "nth-child()" selectors?
 * What's the difference between a relative, fixed, absolute and statically positioned element?
 * What existing CSS frameworks have you used locally, or in production? How would you change/improve them?
 * Have you played around with the new CSS Flexbox or Grid specs?


### PR DESCRIPTION
# Add comparison question about nth-of-type() and nth-child()

Most developers are privy to the use of nth-child(). However, there are certain limitations with this selector. Namely that it targets the proceeding child in the DOM. A caveat of this is that developers are required to amend the nth-child() selector if a new, but different type of element is added before the targeted node. To solve this, nth-of-type() allows you to target the next 'identical' tag in the child list; obviating the need to go back and modify CSS unnecessarily.

- [X] New Question

# Checklist:

- [X] My prose follows the style guidelines of this project
- [X] I have performed a self-review of my own prose