### PR TITLE
Fixed broken heading in Indonesian translation

### DIFF
--- a/Translations/Indonesian/README.md
+++ b/Translations/Indonesian/README.md
@@ -14,7 +14,7 @@ File ini berisi sejumlah pertanyaan teknis yang dapat digunakan saat mewawancara
   1. [Pertanyaan Kinerja](#pertanyaan-kinerja)
   1. [Pertanyaan Jaringan](#pertanyaan-jaringan)
   1. [Pertanyaan Koding](#pertanyaan-koding)
-  1. [Pertanyaan Seru / Sampingan](#pertanyaan-seru-sampingan)
+  1. [Pertanyaan Seru / Sampingan](#pertanyaan-seru--sampingan)
   
 
 ## Cara Partisipasi


### PR DESCRIPTION
The last heading in the Indonesian markdown file is currently broken (invoking it doesn't bring you to the topic). This change fixes it.