### PR TITLE
Fix typo in navigation

### DIFF
--- a/src/_data/questions.json
+++ b/src/_data/questions.json
@@ -50,8 +50,8 @@
       "external": false
     },
     {
-      "abbreviation": "Perfomance",
-      "title": "Perfomance Questions",
+      "abbreviation": "Performance",
+      "title": "Performance Questions",
       "url": "/questions/performance-questions/",
       "external": false
     },


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] Other (please elaborate) 

Corrects a typo in the Questions navigation.
`Performance` was mis-spelled as `perfomance`

# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content
