### PR TITLE
Fix URL and copyright year in footer

### DIFF
--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -1,7 +1,7 @@
 <footer class="footer">
   <p class="footer-text">
-    Copyright &copy; 2012 - 2021. Contributors to
-    <a href="https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/CONTRIBUTORS.md">Front-end-Developer-Interview-Questions.</a><br>
+    Copyright &copy; 2012 - 2022. Contributors to
+    <a href="https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/main/CONTRIBUTORS.md">Front-end-Developer-Interview-Questions.</a><br>
     Curious about the project? <a href="{{ '/about/' | url }}">Read more about here</a>.
   </p>
 </footer>


### PR DESCRIPTION
Fix URL and copyright year in footer

## Type of change

Please delete options that are not relevant.

- [ ] New Question
- [ ] Revision of an existing question
- [x] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 

# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content
