### PR TITLE
Copyright year updated on the website

### DIFF
--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -1,6 +1,6 @@
 <footer class="footer">
   <p class="footer-text">
-    Copyright &copy; 2012 - 2022. Contributors to
+    Copyright &copy; 2012 - 2023. Contributors to
     <a href="https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/main/CONTRIBUTORS.md">Front-end-Developer-Interview-Questions.</a><br>
     Curious about the project? <a href="{{ '/about/' | url }}">Read more about here</a>.
   </p>


### PR DESCRIPTION
Fixes the Copyright year from 2022 to 2023 on the website's footer. The task is simple I don't think it requires that much elaboration.


# Checklist:

- My content follows the style guidelines of this project
- I have performed a self-review of my own content


Thanks!
