### PR TITLE
Update copyright year in footer and license file (#799)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012 - 2019 Contributors to https://github.com/h5bp/Front-end-Developer-Interview-Questions
+Copyright (c) 2012 - 2023 Contributors to https://github.com/h5bp/Front-end-Developer-Interview-Questions
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/_data/helpers.js
+++ b/src/_data/helpers.js
@@ -1,0 +1,6 @@
+module.exports = {
+  currentYear() {
+    const today = new Date();
+    return today.getFullYear();
+  },
+};

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -1,6 +1,6 @@
 <footer class="footer">
   <p class="footer-text">
-    Copyright &copy; 2012 - 2022. Contributors to
+    Copyright &copy; 2012 - {{ helpers.currentYear() }}. Contributors to
     <a href="https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/main/CONTRIBUTORS.md">Front-end-Developer-Interview-Questions.</a><br>
     Curious about the project? <a href="{{ '/about/' | url }}">Read more about here</a>.
   </p>


### PR DESCRIPTION
The copyright year in the website footer and license file was outdated. In this pull request, specifically
- Updated the current year on LICENSE.md file
- Added script to automatically update the current year on the footer

Fixes #799
## Type of change

Please delete options that are not relevant.

- [x] Revision of an existing question
- [x] Infrastructure change (automation, etc.)


# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content


Thanks!
