### PR TITLE
remove space in html-questions

### DIFF
--- a/src/questions/html-questions.md
+++ b/src/questions/html-questions.md
@@ -16,4 +16,4 @@ permalink: /questions/html-questions/index.html
 * Why you would use a `srcset` attribute in an image tag? Explain the process the browser uses when evaluating the content of this attribute.
 * Have you used different HTML templating languages before?
 * What is the difference between `canvas` and `svg`?
-* What are empty elements in HTML ?
+* What are empty elements in HTML?


### PR DESCRIPTION
There looks to be an extra space before a question mark. I removed it to follow the format of other questions.

## Type of change

Please delete options that are not relevant.

- [x] Revision of an existing question


# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content