### PR TITLE
remove cookie question from general-questions

### DIFF
--- a/src/questions/general-questions.md
+++ b/src/questions/general-questions.md
@@ -32,7 +32,6 @@ permalink: /questions/general-questions/index.html
 * What resources do you use to learn about the latest in front end development and design?
 * What skills are needed to be a good front-end developer?
 * What role do you see yourself in?
-* Explain the difference between cookies, session storage, and local storage?
 * Can you explain what happens when you enter a URL into the browser?
 * Describe the difference between SSR and CSR. Discuss the pros and cons. 
   * Are you familiar with static rendering?


### PR DESCRIPTION
This change removes the cookie, session storage, and local storage question from general-questions. This question is [already asked in html-questions](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/4d8ad59101918a9f81e8260d268dfe068b3e3181/src/questions/html-questions.md?plain=1#L12) so I don't think it needs to be repeated here.

If redundancy is okay and we want to keep it in general-questions, I would then suggest ending this with a period instead of a question mark since it is an imperative statement instead of a question.

## Type of change

- [x] Revision of an existing question

# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content