### PR TITLE
Restore alphabetic order of translations

### DIFF
--- a/src/_data/translations.json
+++ b/src/_data/translations.json
@@ -54,12 +54,12 @@
       "url": "german/"
     },
     {
-      "language": "Hebrew",
-      "url": "hebrew/"
-    },
-    {
       "language": "Greek",
       "url": "greek/"
+    },
+    {
+      "language": "Hebrew",
+      "url": "hebrew/"
     },
     {
       "language": "Hindi",


### PR DESCRIPTION
On https://h5bp.org/Front-end-Developer-Interview-Questions/translations/ the Hebrew translation is listed before Greek.

Fixes no open issue

## Type of change

- [X] Other (please elaborate) 
I Swapped positions of Hebrew and Greek in translations.json such that they are displayed in alphabetic order.

# Checklist:

- [X] My content follows the style guidelines of this project
- [X] I have performed a self-review of my own content

By the way, should I first open issues for such changes or is it ok to do a pull request ?
