### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/gh-pages-build.yml
+++ b/.github/workflows/gh-pages-build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "16.x"
       - run: npm install


### PR DESCRIPTION
## Type of change

Other (please elaborate)  
* This PR updates outdated GitHub Action versions.  

## Summary  
This PR updates the versions of GitHub Actions used in the repository's workflows. Specifically, the `actions/checkout` and `actions/setup-node` actions are upgraded from version `v4` to `v6`.  

## Motivation and context  
The update is necessary to ensure compatibility with newer GitHub Actions features and improvements. Version `v6` introduces enhanced functionality, better performance, and improved stability, which are critical for maintaining robust and reliable workflows.  

## Fixes  
# None  

## Dependencies  
- `actions/checkout@v6`  
- `actions/setup-node@v6`  

## Checklist  
- [x] My content follows the style guidelines of this project  
- [x] I have performed a self-review of my own content