### PR TITLE
Fix Contributing guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The project is currently maintained by:
 
 ## Contributors
 
-Feeling inspired? Check our [Contributing guide](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/master/.github/CONTRIBUTING.md) to get started!
+Feeling inspired? Check our [Contributing guide](https://github.com/h5bp/Front-end-Developer-Interview-Questions/blob/main/.github/CONTRIBUTING.md) to get started!
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Updated the link to the Contributing guide to use the main branch.

Fixes https://github.com/h5bp/Front-end-Developer-Interview-Questions/issues/944

## Type of change

Please delete options that are not relevant.
- [x] Other (readme update) 


# Checklist:

- [x] My content follows the style guidelines of this project
- [x] I have performed a self-review of my own content
